### PR TITLE
Fix CodeQL security alerts: ReDoS and shell injection

### DIFF
--- a/lib/protocol_buffers/compiler.rb
+++ b/lib/protocol_buffers/compiler.rb
@@ -1,4 +1,5 @@
 require 'protocol_buffers/compiler/descriptor.pb'
+require 'shellwords'
 
 module ProtocolBuffers
   class CompileError < StandardError; end
@@ -7,11 +8,13 @@ module ProtocolBuffers
     def self.compile(output_filename, input_files, opts = {})
       input_files = Array(input_files) unless input_files.is_a?(Array)
       raise(ArgumentError, "Need at least one input file") if input_files.empty?
-      other_opts = ""
-      (opts[:include_dirs] || []).each { |d| other_opts += " -I#{d}" }
 
-      cmd = "protoc #{other_opts} -o#{output_filename} #{input_files.join(' ')}"
-      rc = system(cmd)
+      cmd = ["protoc"]
+      (opts[:include_dirs] || []).each { |d| cmd << "-I#{d}" }
+      cmd << "-o#{output_filename}"
+      cmd.concat(input_files)
+
+      rc = system(*cmd)
       raise(CompileError, $?.exitstatus.to_s) unless rc
       true
     end

--- a/lib/protocol_buffers/compiler.rb
+++ b/lib/protocol_buffers/compiler.rb
@@ -1,5 +1,4 @@
 require 'protocol_buffers/compiler/descriptor.pb'
-require 'shellwords'
 
 module ProtocolBuffers
   class CompileError < StandardError; end

--- a/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
+++ b/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
@@ -219,7 +219,6 @@ HEADER
   def underscore(camelized_word)
     word = camelized_word.to_s.dup
     word.gsub!(/::/, '/')
-    word.gsub!(/(?:([A-Za-z\d])|^)((?=\a)\b)(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
     word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
     word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
     word.tr!("-", "_")


### PR DESCRIPTION
## Summary
- **Remove ReDoS-vulnerable regex** in `lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb`: The `underscore` method contained a regex with nested lookaheads and alternations (`(?:([A-Za-z\d])|^)((?=\a)\b)(?=\b|[^a-z])`) that exhibited polynomial worst-case backtracking (CodeQL `rb/polynomial-redos`). This pattern was non-functional (matched on `\a` bell character inside a lookahead) and has been removed. The remaining two `gsub!` calls correctly handle CamelCase-to-snake_case conversion.
- **Prevent shell command injection** in `lib/protocol_buffers/compiler.rb`: The `compile` method built a shell command string via interpolation of user-controlled values (`input_files`, `include_dirs`, `output_filename`) and passed it to `system()` as a single string, which invokes a shell (CodeQL `rb/shell-command-constructed-from-input`). Replaced with array form `system(*cmd)` which bypasses shell interpretation entirely, preventing injection.

## Test plan
- [ ] Verify `underscore` method still correctly converts CamelCase to snake_case (e.g., `"FooBarBaz"` -> `"foo_bar_baz"`, `"HTTPSClient"` -> `"https_client"`)
- [ ] Verify `compile` method still correctly invokes `protoc` with include dirs and input files
- [ ] Confirm filenames with spaces or special characters are handled safely by the array form of `system()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)